### PR TITLE
fixed startup error if ~/lu-config/ is missing

### DIFF
--- a/app/scripts/config.js
+++ b/app/scripts/config.js
@@ -2,9 +2,12 @@ var lowdb = require('lowdb')
 var FileSyncAdapter = require('lowdb/adapters/FileSync')
 var path = require('path')
 var os = require('os')
+var fs = require('fs')
 
 class Config {
   constructor(self) {
+    var cpath = path.join(os.homedir(), 'lu-config');
+    if(!fs.existsSync(cpath)) { fs.mkdir(cpath); }
     this.db = lowdb(new FileSyncAdapter(path.join(os.homedir(), 'lu-config', 'rotonde-app.json')))
     
     this.db


### PR DESCRIPTION
Not having a lu-config/ folder in the root of the home directory was preventing the app from starting properly, so this creates one if it doesn't exist.